### PR TITLE
Add markdown formatting pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.3
+    hooks:
+    -   id: prettier
+        files: \.md$

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "proseWrap": "always",
+  "printWidth": 80
+}
+


### PR DESCRIPTION
How to use:

1. Install pre-commit: `pip install pre-commit` or `brew install pre-commit`
1. Install the git hook: `pre-commit install`

Your git commits will now be formatted before the commit.